### PR TITLE
【提議】調整 Collector 輸出邏輯為多面平均分配

### DIFF
--- a/src/main/java/org/Little_100/projecte/devices/EnergyCollectorManager.java
+++ b/src/main/java/org/Little_100/projecte/devices/EnergyCollectorManager.java
@@ -173,6 +173,8 @@ public class EnergyCollectorManager {
                 BlockFace.UP, BlockFace.DOWN
         };
 
+        List<CondenserManager.CondenserState> transferTarget = new ArrayList<>();
+
         for (BlockFace face : faces) {
             Block adjacent = block.getRelative(face);
 
@@ -183,12 +185,24 @@ public class EnergyCollectorManager {
                         .getCondenserState(adjacentLocation);
 
                 if (condenserState != null) {
-                    condenserState.addEmc(data.storedEmc);
-                    data.storedEmc = 0;
-                    return;
+                    transferTarget.add(condenserState);
                 }
             }
         }
+
+        if (transferTarget.isEmpty()) {
+            return;
+        }
+
+        int count = transferTarget.size();
+        if (data.storedEmc < count) return;
+
+        long avgEmc = data.storedEmc / count;
+        for (CondenserManager.CondenserState condenserState : transferTarget) {
+            condenserState.addEmc(avgEmc);
+        }
+
+        data.storedEmc -= avgEmc * count;
     }
 
     private void saveAllCollectors() {


### PR DESCRIPTION
在當前項目中，EMC 僅對一面的方塊輸出後便退出函數，
而在原版 ProjectE 中，Collector 會對相鄰六面的可接收 EMC 的方塊將 EMC 均勻分配到每一個方塊中，

為了更還原 ProjectE 的遊戲體驗，希望能調整成與原版一致的輸出邏輯。
這是我修改後的輸出邏輯代碼，望參考：